### PR TITLE
Handle SIGHUP gracefully

### DIFF
--- a/composer/composer.go
+++ b/composer/composer.go
@@ -194,7 +194,7 @@ func (c *Composer) registerOutput(service *Service, readerFn func() (io.ReadClos
 
 func (c *Composer) startServices() error {
 	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGHUP)
 
 	for i := range c.services {
 		service := c.services[i]


### PR DESCRIPTION
When controlling terminal closes, it sends a SIGHUP to the running process.

Because `composer` doesn't handle that signal, it leaves sub-processes running whenever a terminal is closed.

This MR fixes that.