### PR TITLE
Wait for all services

### DIFF
--- a/composer.go
+++ b/composer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -21,8 +22,15 @@ func main() {
 		os.Exit(errCode)
 	}
 
+	var waitForAll bool
+	flag.BoolVar(&waitForAll, "wait", false, "wait for all services to finish")
+	flag.Parse()
+
 	if len(os.Args) <= 1 {
-		fmt.Printf("\nUsage: %s SERVICE [SERVICE ...]\n\nAvailable services:\n", os.Args[0])
+		fmt.Printf("\nUsage: %s [options] SERVICE [SERVICE ...]\n\nOptions:\n", os.Args[0])
+		flag.PrintDefaults()
+
+		fmt.Println("\nServices:")
 		for service := range cfg.Services {
 			fmt.Println(" -", service)
 		}
@@ -30,7 +38,7 @@ func main() {
 		os.Exit(errCode)
 	}
 
-	services := os.Args[1:]
+	services := flag.Args()
 
 	var c *composer.Composer
 	if c, err = composer.New(*cfg, services...); err != nil {
@@ -38,7 +46,13 @@ func main() {
 		os.Exit(errCode)
 	}
 
-	if err = c.Run(); err != nil {
+	if waitForAll {
+		err = c.RunAll(services...)
+	} else {
+		err = c.Run()
+	}
+
+	if err != nil {
 		fmt.Println("Error running composer:", err)
 		os.Exit(errCode)
 	}

--- a/composer/composer_test.go
+++ b/composer/composer_test.go
@@ -41,3 +41,64 @@ func TestKill(t *testing.T) {
 		t.Errorf("process should be killed after %v seconds, it took %v instead", killAfter, time.Since(start))
 	}
 }
+
+func TestRunAll(t *testing.T) {
+	cfg := composer.Config{
+		Version: composer.Version,
+		Services: map[string]composer.ServiceConfig{
+			"s1": {Command: "sleep 0.1"},
+			"s2": {Command: "sleep 0.2"},
+		},
+	}
+
+	c, err := composer.New(cfg, "s1", "s2")
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+
+	// c.EnableDebug()
+
+	start := time.Now()
+
+	if err = c.RunAll("s1", "s2"); err != nil {
+		if !strings.Contains(err.Error(), "interrupted by user") {
+			t.Errorf("error running composer: %v", err)
+		}
+	}
+
+	const doneAfter = 200 * time.Millisecond
+	if time.Since(start) < doneAfter {
+		t.Errorf("process should be done after %v seconds, it took %v instead", doneAfter, time.Since(start))
+	}
+}
+
+func TestRunAll_DependencyExistsFirst(t *testing.T) {
+	cfg := composer.Config{
+		Version: composer.Version,
+		Services: map[string]composer.ServiceConfig{
+			"b1": {Command: "sleep 0.1"},
+			"s1": {Command: "sleep 0.2"},
+			"s2": {Command: "sleep 0.3", DependsOn: []string{"b1"}},
+		},
+	}
+
+	c, err := composer.New(cfg, "s1", "s2")
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+
+	c.EnableDebug()
+
+	start := time.Now()
+
+	if err = c.RunAll("s1", "s2"); err != nil {
+		if !strings.Contains(err.Error(), "interrupted by user") {
+			t.Errorf("error running composer: %v", err)
+		}
+	}
+
+	const doneAfter = 150 * time.Millisecond
+	if time.Since(start) > doneAfter {
+		t.Errorf("process should be done after %v seconds, it took %v instead", doneAfter, time.Since(start))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/t12y/composer
 
 go 1.17
 
-require (
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-)
+require gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=


### PR DESCRIPTION
Currently composer exists when any of the services exists.

This change allows composer to wait for all specified services to finish before composer process exits.

E.g.: running `composer -wait service1 service2` will cause composer to wait until both services are completed or any of their dependencies exit prematurely.