### PR TITLE
support large command output

### DIFF
--- a/composer/composer_test.go
+++ b/composer/composer_test.go
@@ -1,12 +1,36 @@
 package composer_test
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/t12y/composer/composer"
 )
+
+func captureStdoutStderr(fn func()) string {
+	originalStdout, originalStderr := os.Stdout, os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stdout, os.Stderr = w, w
+
+	result := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		result <- buf.String()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout, os.Stderr = originalStdout, originalStderr
+
+	return <-result
+}
 
 func TestKill(t *testing.T) {
 	cfg := composer.Config{
@@ -76,9 +100,9 @@ func TestRunAll_DependencyExistsFirst(t *testing.T) {
 	cfg := composer.Config{
 		Version: composer.Version,
 		Services: map[string]composer.ServiceConfig{
-			"b1": {Command: "sleep 0.1"},
+			"b1": {Command: "sleep 0.3"},
 			"s1": {Command: "sleep 0.2"},
-			"s2": {Command: "sleep 0.3", DependsOn: []string{"b1"}},
+			"s2": {Command: "sleep 0.1", DependsOn: []string{"b1"}},
 		},
 	}
 
@@ -97,8 +121,40 @@ func TestRunAll_DependencyExistsFirst(t *testing.T) {
 		}
 	}
 
-	const doneAfter = 150 * time.Millisecond
-	if time.Since(start) > doneAfter {
-		t.Errorf("process should be done after %v seconds, it took %v instead", doneAfter, time.Since(start))
+	const doneAfter = 300 * time.Millisecond
+	if time.Since(start) < doneAfter {
+		t.Errorf("process should be done after %v milliseconds, it took %v instead", doneAfter, time.Since(start))
+	}
+}
+
+func TestLargeOutput(t *testing.T) {
+	// outputLength should be > 64k to be sure we can support arbitrarily large outputs
+	// see: `MaxScanTokenSize` value at https://pkg.go.dev/bufio#pkg-constants
+	const outputLength = 70_000
+
+	expectedOutput := strings.Repeat("0", outputLength)
+	cmd := "printf '%0" + strconv.Itoa(outputLength) + "d' 0"
+
+	cfg := composer.Config{
+		Version:  composer.Version,
+		Services: map[string]composer.ServiceConfig{"s1": {Command: cmd}},
+	}
+
+	c, err := composer.New(cfg, "s1")
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+
+	// c.EnableDebug()
+
+	output := captureStdoutStderr(func() { err = c.Run() })
+	if err != nil {
+		if !strings.Contains(err.Error(), "interrupted by user") {
+			t.Errorf("error running composer: %v", err)
+		}
+	}
+
+	if !strings.Contains(output, expectedOutput) {
+		t.Errorf("expected large output value not found in actual execution output:\nwant: '%s'\ngot '%s'", expectedOutput, output)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/t12y/composer
 
 go 1.17
 
-require gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- fix `scanner error: bufio.Scanner: token too long` error for large command output (i.e. >64k)
- fix `TestRunAll_DependencyExistsFirst` test