### PR TITLE
ensure we do not block on dependency output

### DIFF
--- a/composer/composer_test.go
+++ b/composer/composer_test.go
@@ -100,7 +100,7 @@ func TestRunAll_DependencyExistsFirst(t *testing.T) {
 	cfg := composer.Config{
 		Version: composer.Version,
 		Services: map[string]composer.ServiceConfig{
-			"b1": {Command: "sleep 0.3"},
+			"b1": {Command: "sleep 0.3 && echo 'ok'", ReadyOn: "ok"},
 			"s1": {Command: "sleep 0.2"},
 			"s2": {Command: "sleep 0.1", DependsOn: []string{"b1"}},
 		},
@@ -111,7 +111,7 @@ func TestRunAll_DependencyExistsFirst(t *testing.T) {
 		t.Errorf("error: %v", err)
 	}
 
-	c.EnableDebug()
+	// c.EnableDebug()
 
 	start := time.Now()
 
@@ -156,5 +156,56 @@ func TestLargeOutput(t *testing.T) {
 
 	if !strings.Contains(output, expectedOutput) {
 		t.Errorf("expected large output value not found in actual execution output:\nwant: '%s'\ngot '%s'", expectedOutput, output)
+	}
+}
+
+func TestDaemonDependencies(t *testing.T) {
+	const expectedOutput = "hello world"
+	const unexpectedOutput = "goodbye cruel world"
+
+	cfg := composer.Config{
+		Version: composer.Version,
+		Services: map[string]composer.ServiceConfig{
+			"s1": {
+				// the main service will exit immediately - however, it should wait on all dependencies to become ready
+				// before executing, and then any remaining dependency services can be killed
+				Command:   "echo 'hello from s1'",
+				DependsOn: []string{"d1"},
+			},
+			"d1": {
+				// the first child dependency will exit after 2 seconds but is ready immediately - this simulates a
+				// dependency that runs forever in the background and should be killed after the main service exits
+				Command:   "sleep 2 && echo '" + unexpectedOutput + "'",
+				DependsOn: []string{"d2"},
+			},
+			"d2": {
+				// the first grandchild dependency will signal ready after 1 second and then exit immediately - this
+				// ensures the main service actually blocks on all dependencies to become ready before executing
+				ReadyOn: expectedOutput,
+				Command: "sleep 1 && echo '" + expectedOutput + "'",
+			},
+		},
+	}
+
+	c, err := composer.New(cfg, "s1")
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+
+	// c.EnableDebug()
+
+	output := captureStdoutStderr(func() { err = c.Run() })
+	if err != nil {
+		if !strings.Contains(err.Error(), "interrupted by user") {
+			t.Errorf("error running composer: %v", err)
+		}
+	}
+
+	if !strings.Contains(output, expectedOutput) {
+		t.Errorf("expected output value not found in actual execution output:\nwant: '%s'\ngot '%s'", expectedOutput, output)
+	}
+
+	if strings.Contains(output, unexpectedOutput) {
+		t.Errorf("unexpected output value found in actual execution output:\nunexpected: '%s'\ngot '%s'", unexpectedOutput, output)
 	}
 }

--- a/composer/service.go
+++ b/composer/service.go
@@ -10,14 +10,15 @@ import (
 )
 
 type Service struct {
-	id          int
-	name        string
-	readyOn     string
-	workdir     string
-	command     string
-	dependsOn   []string
-	environment map[string]string
-	killTimeout time.Duration
+	id           int
+	isDependency bool
+	name         string
+	readyOn      string
+	workdir      string
+	command      string
+	dependsOn    []string
+	environment  map[string]string
+	killTimeout  time.Duration
 
 	logPrefix string
 


### PR DESCRIPTION
Fix an issue introduced in https://github.com/t12y/composer/pull/5 that would cause composer to block on all the output of _all_ services (even dependencies) before exiting. This is not the correct behavior because dependency services are often daemons that will never naturally exit / close their stdout / stderr pipes (e.g. db servers, cache servers, etc...).