### PR TITLE
ensure all child processes are cleaned up

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.25
 
       - name: Test
         run: go test -v ./...

--- a/composer/composer.go
+++ b/composer/composer.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -60,6 +61,10 @@ func New(cfg Config, initServices ...string) (*Composer, error) {
 // Run starts all services
 func (c *Composer) Run() error {
 	c.info("Preparing composer")
+
+	if err := BecomeSubreaper(); err != nil {
+		return err
+	}
 
 	const maxOpenFiles = 65000
 	opeFilesRLimit := &syscall.Rlimit{
@@ -336,20 +341,21 @@ func (c *Composer) cleanupService(service *Service) {
 
 	pid := service.cmd.Process.Pid
 
+	// snapshot descendants once, before anything dies
+	descendants := c.collectDescendants(pid)
+
 	killTimer := time.AfterFunc(service.killTimeout, func() {
 		c.debug("cleanup %s - killing %d", service.name, pid)
-		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "error killing service %s with PID %d\n", service.name, pid)
-		}
+		c.signalAll(descendants, pid, syscall.SIGKILL)
 	})
 	defer killTimer.Stop()
 
 	c.debug("cleanup %s - interrupting %d", service.name, pid)
-	if err := syscall.Kill(-pid, syscall.SIGINT); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error interrupting service %s with PID %d\n", service.name, pid)
+	c.signalAll(descendants, pid, syscall.SIGINT)
+
+	if _, err := service.cmd.Process.Wait(); err != nil && !errors.Is(err, syscall.ECHILD) {
+		_, _ = fmt.Fprintf(os.Stderr, "error waiting for service %s with PID %d to die: %+v\n", service.name, pid, err)
 	}
 
-	if _, err := service.cmd.Process.Wait(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error waiting for service %s with PID %d to die\n", service.name, pid)
-	}
+	c.reapDescendants(descendants)
 }

--- a/composer/composer_test.go
+++ b/composer/composer_test.go
@@ -2,10 +2,13 @@ package composer_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -63,6 +66,69 @@ func TestKill(t *testing.T) {
 	const killAfter = 3 * time.Second
 	if time.Since(start) > killAfter {
 		t.Errorf("process should be killed after %v seconds, it took %v instead", killAfter, time.Since(start))
+	}
+}
+
+func TestKillProcessTree(t *testing.T) {
+	tmpDir := t.TempDir()
+	pidFile := filepath.Join(tmpDir, "child.pid")
+
+	// this script does three things:
+	// 1. traps SIGINT so the parent ignores the polite shutdown (forcing the KillTimeout)
+	// 2. spawns a background subshell with a sleep command, recording its PID
+	// 3. waits indefinitely
+	cmdStr := fmt.Sprintf("trap '' INT; sleep 10 & echo $! > %s; wait", pidFile)
+
+	cfg := composer.Config{
+		Version: composer.Version,
+		Services: map[string]composer.ServiceConfig{
+			"tree_test": {
+				Command:     cmdStr,
+				KillTimeout: 1,
+			},
+		},
+	}
+
+	c, err := composer.New(cfg, "tree_test")
+	if err != nil {
+		t.Fatalf("error initializing composer: %v", err)
+	}
+
+	//c.EnableDebug()
+
+	time.AfterFunc(time.Second, c.Interrupt)
+
+	start := time.Now()
+
+	if err = c.Run(); err != nil {
+		if !strings.Contains(err.Error(), "interrupted by user") {
+			t.Errorf("error running composer: %v", err)
+		}
+	}
+
+	const killAfter = 3 * time.Second
+	if time.Since(start) > killAfter {
+		t.Errorf("process should be killed after %v, it took %v instead", killAfter, time.Since(start))
+	}
+
+	// ensure the child PID was killed
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("failed to read child PID file (was the child ever spawned?): %v", err)
+	}
+
+	childPid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("invalid PID in file: %s", string(pidBytes))
+	}
+
+	// check if the child process is still running
+	if err = syscall.Kill(childPid, 0); err == nil {
+		// the signal was delivered successfully, meaning the process is still alive
+		// clean it up forcefully so it doesn't leak memory in the test runner
+		_ = syscall.Kill(childPid, syscall.SIGKILL)
+
+		t.Errorf("child process %d was left orphaned and running", childPid)
 	}
 }
 

--- a/composer/process.go
+++ b/composer/process.go
@@ -1,0 +1,53 @@
+package composer
+
+import (
+	"errors"
+	"syscall"
+)
+
+// collectDescendants returns all process IDs for processes spawned under the root process
+func (c *Composer) collectDescendants(root int) (out []int) {
+	tree, err := getProcessTree()
+	if err != nil {
+		c.debug("getProcessTree failed: %+v", err)
+		return nil
+	}
+
+	var walk func(int)
+	walk = func(pid int) {
+		for _, child := range tree[pid] {
+			walk(child)
+			out = append(out, child)
+		}
+	}
+	walk(root)
+
+	return out
+}
+
+// signalAll kills all descendant processes spawned under the root process before killing the root process
+func (c *Composer) signalAll(descendants []int, root int, sig syscall.Signal) {
+	for _, pid := range descendants {
+		if err := syscall.Kill(pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
+			c.debug("failed to kill descendant PID %d (%d): %v", pid, sig, err)
+		}
+	}
+
+	if err := syscall.Kill(root, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
+		c.debug("failed to kill root PID %d (%d): %v", root, sig, err)
+	}
+}
+
+// reapDescendants reap all descendant processes spawned under the root process that may have been re-parented to us so
+// they don't linger as zombies
+func (c *Composer) reapDescendants(descendants []int) {
+	for _, dpid := range descendants {
+		for {
+			_, err := syscall.Wait4(dpid, nil, 0, nil)
+			if errors.Is(err, syscall.EINTR) {
+				continue
+			}
+			break
+		}
+	}
+}

--- a/composer/process_darwin.go
+++ b/composer/process_darwin.go
@@ -1,0 +1,36 @@
+//go:build darwin
+
+package composer
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// BecomeSubreaper is a no-op on macOS. Darwin has no equivalent of
+// Linux's PR_SET_CHILD_SUBREAPER, so orphaned descendants are reparented
+// to launchd (PID 1) and lineage tracking through intermediate parent
+// deaths is not possible on this platform. Provided for API symmetry
+// with the Linux build so cross-platform callers don't need build tags.
+func BecomeSubreaper() error {
+	return nil
+}
+
+// getProcessTree returns a map from parent PID to child PIDs, built from
+// the kernel's process table via sysctl(KERN_PROC_ALL). Best-effort
+// snapshot: reparented orphans appear under their current parent
+// (typically launchd) rather than their original ancestor. See
+// BecomeSubreaper for why this is unavoidable on Darwin.
+func getProcessTree() (map[int][]int, error) {
+	kprocs, err := unix.SysctlKinfoProcSlice("kern.proc.all")
+	if err != nil {
+		return nil, err
+	}
+
+	tree := make(map[int][]int)
+	for i := range kprocs {
+		pid := int(kprocs[i].Proc.P_pid)
+		ppid := int(kprocs[i].Eproc.Ppid)
+		tree[ppid] = append(tree[ppid], pid)
+	}
+	return tree, nil
+}

--- a/composer/process_linux.go
+++ b/composer/process_linux.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package composer
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// BecomeSubreaper marks the calling process as a "child subreaper".
+// Descendants whose intermediate ancestors exit are reparented to this
+// process instead of to PID 1, so every descendant remains reachable from
+// os.Getpid() in the tree returned by getProcessTree, no matter how many
+// intermediate parents have died.
+//
+// Call once at startup, before spawning any subprocesses. The flag is
+// process-wide (not inherited by children) and only needs to be set on the
+// topmost ancestor; orphans reparent to the nearest living ancestor
+// subreaper. Requires Linux 3.4+.
+func BecomeSubreaper() error {
+	return unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+}
+
+// getProcessTree returns a map from parent PID to child PIDs, built from
+// /proc. Best-effort snapshot: processes may exit mid-scan. When
+// BecomeSubreaper has been called at startup, every descendant of this
+// process is reachable from os.Getpid() in the returned tree.
+func getProcessTree() (map[int][]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+
+	tree := make(map[int][]int)
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		ppid, ok := readPPID("/proc/" + entry.Name() + "/status")
+		if !ok {
+			continue
+		}
+		tree[ppid] = append(tree[ppid], pid)
+	}
+	return tree, nil
+}
+
+// readPPID extracts the PPid field from a /proc/[pid]/status file. Returns
+// false if the file can't be read or the field is missing (process exited
+// mid-scan, permission denied, etc).
+func readPPID(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	prefix := []byte("PPid:")
+	for len(data) > 0 {
+		nl := bytes.IndexByte(data, '\n')
+		var line []byte
+		if nl < 0 {
+			line, data = data, nil
+		} else {
+			line, data = data[:nl], data[nl+1:]
+		}
+		if !bytes.HasPrefix(line, prefix) {
+			continue
+		}
+		fields := bytes.Fields(line)
+		if len(fields) < 2 {
+			return 0, false
+		}
+		ppid, err := strconv.Atoi(string(fields[1]))
+		if err != nil {
+			return 0, false
+		}
+		return ppid, true
+	}
+	return 0, false
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/t12y/composer
 
-go 1.17
+go 1.25.0
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	golang.org/x/sys v0.43.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Even though we were using process groups already, some tools (e.g. gcloud) explicitly use separate, detached process groups. To ensure we always cleanup all child processes we need to manually construct a process tree and then kill processes from the bottom up.